### PR TITLE
Fix build errors in entry.S. allows helloworld to compile and link.

### DIFF
--- a/drivers/bl702_driver/startup/GCC/entry.S
+++ b/drivers/bl702_driver/startup/GCC/entry.S
@@ -48,13 +48,14 @@ _enter:
      * called. */
     .weak __StackTop
     la sp, __StackTop
-    
+
     /* Intial the mtvt, MUST BE 64 bytes aligned*/
     .weak __Vectors
     la t0, __Vectors
-    csrw mtvt, t0
+    // From drivers/bl702_driver/risc-v/Core/Include/riscv_encoding.h
+    csrw CSR_MTVT, t0
 
-#if __riscv_float_abi_single
+#if defined(__riscv_float_abi_single)
     /* deal with FP */
     /* Is F extension present? */
     csrr t0, misa


### PR DESCRIPTION
1) __riscv_float_abi_single is not in the provided preprocessor namespace.
The default build sets -Werror and has -Warn implicitly. Testing something
that's not defined with an #if is therefore an error.
This is possibly a behavior change. If your builds ever define that AND
set it to 0, this way will fail, but #if defined (foo) + #if foo is akward
and probably not what you intended.

2) "csrw mtvt, t0" is not legal in at least
GNU assembler (GNU Binutils) 2.35
   Fortunately, riscv_encoding.h #defines a perfectly lovely value of
$0x307 that's appropriate for the chips AND is compatible with more assemblers.
This appears to be  an extension in
GNU assembler (SiFive Binutils 2.32.0-2019.08.0) 2.32
(present in bl_io_sdk, as provided by SiFive)
and that's probably what's in  your $PATH, but not relying on vendor
extension in this case is dead easy.

Two distinct problems. No, I'm not making different pull requests.
...this is a lot of words for a two line change. :-)