### PR TITLE
Add missing declarations bl602_ef_ctrl.h needed to build for BL602

### DIFF
--- a/drivers/bl602_driver/std_drv/inc/bl602_ef_ctrl.h
+++ b/drivers/bl602_driver/std_drv/inc/bl602_ef_ctrl.h
@@ -197,6 +197,26 @@ typedef struct
     uint32_t rsvd    : 24; /*!< Reserved */
 } Efuse_Capcode_Info_Type;
 
+/**
+ *  @brief Efuse Ldo11 Vout Sel Trim definition
+ */
+typedef struct {
+    uint32_t sel_value                              :  4;    /*!< value trim */
+    uint32_t parity                                  :  1;    /*!< Parity of capcode */
+    uint32_t en                                      :  1;    /*!< Enable status */
+    uint32_t rsvd                                    : 26;    /*!< Reserved */
+}Efuse_Ldo11VoutSelTrim_Info_Type;
+
+/**
+ *  @brief Efuse Tx Power definition
+ */
+typedef struct {
+    uint32_t txpower                                 :  5;    /*!< txpower value  */
+    uint32_t parity                                  :  1;    /*!< Parity of capcode */
+    uint32_t en                                      :  1;    /*!< Enable status */
+    uint32_t rsvd                                    : 25;    /*!< Reserved */
+}Efuse_TxPower_Info_Type;
+
 /*@} end of group EF_CTRL_Public_Types */
 
 /** @defgroup  EF_CTRL_Public_Constants


### PR DESCRIPTION
Add missing declarations (Efuse_Ldo11VoutSelTrim_Info_Type and Efuse_TxPower_Info_Type) in bl602_ef_ctrl.h to build with -DCHIP=bl602. These declarations come from https://github.com/bouffalolab/bl_iot_sdk/blob/master/components/bl602/bl602_std/bl602_std/StdDriver/Inc/bl602_ef_ctrl.h.

Fixes https://github.com/bouffalolab/bl_mcu_sdk/issues/6.