### PR TITLE
Allow to use the SDK from a subfolder of another project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/tools/cmake/riscv64-unknown-elf-gcc.cmake)
+include(${CMAKE_SOURCE_DIR}/drivers/${CHIP}_driver/cpu_flags.cmake)
 include(${CMAKE_SOURCE_DIR}/tools/cmake/compiler_flags.cmake)
 include(${CMAKE_SOURCE_DIR}/tools/cmake/tools.cmake)
 

--- a/tools/cmake/compiler_flags.cmake
+++ b/tools/cmake/compiler_flags.cmake
@@ -1,5 +1,3 @@
-include(${CMAKE_SOURCE_DIR}/drivers/${CHIP}_driver/cpu_flags.cmake)
-
 list(APPEND GLOBAL_C_FLAGS -Os -g3)
 list(APPEND GLOBAL_C_FLAGS -fshort-enums -fno-common -fms-extensions -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -ffast-math)
 list(APPEND GLOBAL_C_FLAGS -Wall -Wshift-negative-value -Wchar-subscripts -Wformat -Wuninitialized -Winit-self -Wignored-qualifiers -Wunused -Wundef)


### PR DESCRIPTION
I would like to use the MCU SDK in another project structured like this:

MyProject/
  | - sdk/
  | -  | - <Content of this repo>
  | - src/
  | -  | - main.cpp
  | - CMakeLists.txt

The SDK would be included (as a git submodule) in the `sdk` subfolder. The sources of my own project are stored in `src`. And the root `CMakeLists.txt` file glues everything together.

The only think that prevent me from doing this is the include of `cpu_flags.cmake` in `compiler_flags.cmake`.
Moving this include into the main CMakeLists.txt file fixes the issue.

If needed, I can push my own project using the SDK as soon as I've cleaned the code a bit :)
**EDIT** : [here is my project](https://github.com/JF002/bl602_cmake_mcusdk)