### PR TITLE
fix bl702_iot as target board

### DIFF
--- a/bsp/board/bl702/bl702_config.h
+++ b/bsp/board/bl702/bl702_config.h
@@ -36,6 +36,10 @@
 #include "bl706_lp/peripheral_config.h"
 #include "bl706_lp/clock_config.h"
 #include "bl706_lp/pinmux_config.h"
+#elif defined(bl702_iot)
+#include "bl702_iot/peripheral_config.h"
+#include "bl702_iot/clock_config.h"
+#include "bl702_iot/pinmux_config.h"
 #else
 #include "bl70x_custom/peripheral_config.h"
 #include "bl70x_custom/clock_config.h"


### PR DESCRIPTION
I have tried compiling examples with bl702_iot specified as BOARD, but it doesn't work without this change.
