### PR TITLE
[feat][zephyr] Enable bl_mcu_sdk as zephyr module

### DIFF
--- a/drivers/bl602_driver/hal_drv/src/hal_mtimer.c
+++ b/drivers/bl602_driver/hal_drv/src/hal_mtimer.c
@@ -22,6 +22,7 @@
  */
 #include "hal_mtimer.h"
 #include "bl602_glb.h"
+#include "risc-v/Core/Include/clic.h"
 
 static void (*systick_callback)(void);
 static uint64_t next_compare_tick = 0;

--- a/drivers/bl602_driver/regs/bl602.h
+++ b/drivers/bl602_driver/regs/bl602.h
@@ -247,25 +247,5 @@ typedef enum {
   */
 #include <stdint.h>
 #include <system_bl602.h>
-/* ARM CPU include files */
-#ifdef ARCH_ARM
-#ifdef CPU_AP_CM4
-#include "core_cm4.h" /* Cortex-M4 processor and core peripherals */
-#endif
-#ifdef CPU_NP_CM0
-#include "core_cm0.h" /* Cortex-M0 processor and core peripherals */
-#endif
-#endif
-/* RISCV CPU include files */
-#ifdef ARCH_RISCV
-#ifdef __GNUC__
-#include "../risc-v/Core/Include/clic.h"
-#include "../risc-v/Core/Include/riscv_encoding.h"
-#endif
-#endif
-
-/**
-  * @}
-  */
 
 #endif

--- a/drivers/bl602_driver/startup/interrupt.c
+++ b/drivers/bl602_driver/startup/interrupt.c
@@ -22,6 +22,8 @@
  */
 #include "bl602_common.h"
 #include "bflb_platform.h"
+#include "risc-v/Core/Include/clic.h"
+#include "risc-v/Core/Include/riscv_encoding.h"
 
 pFunc __Interrupt_Handlers[IRQn_LAST] = { 0 };
 

--- a/drivers/bl602_driver/startup/system_bl602.c
+++ b/drivers/bl602_driver/startup/system_bl602.c
@@ -1,6 +1,7 @@
 #include "bl602.h"
 #include "bl602_glb.h"
 #include "bl602_hbn.h"
+#include "risc-v/Core/Include/clic.h"
 
 /*----------------------------------------------------------------------------
   Define clocks

--- a/drivers/bl702_driver/hal_drv/src/hal_mtimer.c
+++ b/drivers/bl702_driver/hal_drv/src/hal_mtimer.c
@@ -22,6 +22,7 @@
  */
 #include "hal_mtimer.h"
 #include "bl702_glb.h"
+#include "risc-v/Core/Include/clic.h"
 
 static void (*systick_callback)(void);
 static uint64_t next_compare_tick = 0;

--- a/drivers/bl702_driver/regs/bl702.h
+++ b/drivers/bl702_driver/regs/bl702.h
@@ -299,22 +299,6 @@ typedef enum {
   */
 #include <stdint.h>
 #include <system_bl702.h>
-/* ARM CPU include files */
-#ifdef ARCH_ARM
-#ifdef CPU_AP_CM4
-#include "core_cm4.h" /* Cortex-M4 processor and core peripherals */
-#endif
-#ifdef CPU_NP_CM0
-#include "core_cm0.h" /* Cortex-M0 processor and core peripherals */
-#endif
-#endif
-/* RISCV CPU include files */
-#ifdef ARCH_RISCV
-#ifdef __GNUC__
-#include "../risc-v/Core/Include/clic.h"
-#include "../risc-v/Core/Include/riscv_encoding.h"
-#endif
-#endif
 
 /**
   * @}

--- a/drivers/bl702_driver/startup/interrupt.c
+++ b/drivers/bl702_driver/startup/interrupt.c
@@ -22,6 +22,8 @@
  */
 #include "bl702_common.h"
 #include "bflb_platform.h"
+#include "risc-v/Core/Include/clic.h"
+#include "risc-v/Core/Include/riscv_encoding.h"
 
 pFunc __Interrupt_Handlers[IRQn_LAST] = { 0 };
 

--- a/drivers/bl702_driver/startup/system_bl702.c
+++ b/drivers/bl702_driver/startup/system_bl702.c
@@ -23,6 +23,7 @@
 #include "bl702.h"
 #include "bl702_glb.h"
 #include "bl702_hbn.h"
+#include "risc-v/Core/Include/clic.h"
 
 #ifdef BFLB_EFLASH_LOADER
 #include "bl702_usb.h"


### PR DESCRIPTION
The [ZephyrRTOS](https://zephyrproject.org/) is a newer Open Source RTOS. It strives to deliver the best-in-class RTOS for connected resource-constrained devices, built to be secure and safe.

This add ZephyrRTOS entry point and define environment to build Bouffalo Lab low level peripheral drivers as hal_bouffalolab. Initially, bl602 is the target but can be extended to any other SoC series present in the bl_mcu_sdk.

The commit sequence try fix small issues found due to code isolation. The BFLB_USE_PLATFORM was necessary to be created to isolate low level drivers and Bouffalo Lab HAL, once Zephyr have their own.

The zephyr directory is completely isolated from bl_mcu_sdk and not interfere. This layout was created to allow add manufacturer repositories as external modules into ZephyrRTOS.

Currently there is a minimal attempt to enable Bouffalo Lab SoC at ZephyrRTOS at [PR 37686](https://github.com/zephyrproject-rtos/zephyr/pull/37686)

How to Build/Flash on a working zephyr environment:

1. Clone PR 37686
2. Read board/riscv/dt_bl10_devkit/doc/index.rst
2. west update
3. west build -b dt_bl10_devkit samples/hello_world
4. west flash