### PR TITLE
Add MJPEG to device table only for D0 core

### DIFF
--- a/drivers/lhal/config/bl808/device_table.c
+++ b/drivers/lhal/config/bl808/device_table.c
@@ -191,6 +191,7 @@ struct bflb_device_s bl808_device_table[] = {
       .sub_idx = 0,
       .dev_type = BFLB_DEVICE_TYPE_CKS,
       .user_data = NULL },
+#if defined(CPU_D0)
     { .name = "mjpeg",
       .reg_base = MJPEG_BASE,
       .irq_num = BL808_IRQ_MJPEG,
@@ -198,6 +199,7 @@ struct bflb_device_s bl808_device_table[] = {
       .sub_idx = 0,
       .dev_type = BFLB_DEVICE_TYPE_MJPEG,
       .user_data = NULL },
+#endif
 };
 
 struct bflb_device_s *bflb_device_get_by_name(const char *name)


### PR DESCRIPTION
Build of hello_world failed due missing `BL808_IRQ_MJPEG`.
From this it looks like MJPEG core is available only for D0 core,
thus making MJPEG core in table only for D0 core.