### PR TITLE
Fix bflb_flash_get_jedec_id() for BL602

### DIFF
--- a/drivers/soc/bl602/port/bl602_flash.c
+++ b/drivers/soc/bl602/port/bl602_flash.c
@@ -95,7 +95,7 @@ int ATTR_TCM_SECTION bflb_flash_init(void)
     return ret;
 }
 
-uint32_t bflb_flash_get_jedecid(void)
+uint32_t bflb_flash_get_jedec_id(void)
 {
     uint32_t jid = 0;
 


### PR DESCRIPTION
Rename "bflb_flash_get_jedecid()" to bflb_flash_get_jedec_id() (in bl602_flash.c) to be consistent with the declaration in bflb_flash.h.

Fixes a build/link error when building for BL602.