### PR TITLE
Fix compile error when using TLSF memory manager

### DIFF
--- a/bsp/board/bl808dk/board.c
+++ b/bsp/board/bl808dk/board.c
@@ -267,8 +267,13 @@ void board_init(void)
 
     bl_show_log();
     bl_show_flashinfo();
-
+#ifdef CONFIG_TLSF
+    bflb_tlsf_size_container_t *tlsf_size = bflb_tlsf_stats();
+    printf("TLSF Dynamic Memory Init Success: Heap Size = %d Kbyte, Used Size = %d Kbyte, Free Size = %d Kbyte\r\n",
+           tlsf_size->free + tlsf_size->used / 1024, tlsf_size->used / 1024, tlsf_size->free / 1024);
+#else
     printf("dynamic memory init success,heap size = %d Kbyte \r\n", system_mmheap[0].mem_size / 1024);
+#endif
 
     printf("sig1:%08x\r\n", BL_RD_REG(GLB_BASE, GLB_UART_CFG1));
     printf("sig2:%08x\r\n", BL_RD_REG(GLB_BASE, GLB_UART_CFG2));

--- a/components/freertos/CMakeLists.txt
+++ b/components/freertos/CMakeLists.txt
@@ -7,8 +7,11 @@ sdk_library_add_sources(tasks.c)
 sdk_library_add_sources(timers.c)
 sdk_library_add_sources(timers.c)
 sdk_library_add_sources(freertos_port.c)
+if(CONFIG_TLSF)
+sdk_library_add_sources(portable/MemMang/heap_3.c)
+else()
 sdk_library_add_sources(portable/MemMang/heap_5.c)
-
+endif()
 sdk_add_include_directories(include)
 
 if(("${CHIP}" STREQUAL "bl808") AND ("${CPU_ID}" STREQUAL "d0"))

--- a/components/tlsf/bflb_tlsf.c
+++ b/components/tlsf/bflb_tlsf.c
@@ -57,3 +57,21 @@ void *bflb_malloc_align(size_t align, size_t size)
 
     return ptr;
 }
+
+void tlsf_size_walker(void* ptr, size_t size, int used, void* user)
+{
+    if (used) {
+        ((bflb_tlsf_size_container_t *)user)->used += (unsigned int)size;
+    }
+    else {
+        ((bflb_tlsf_size_container_t *)user)->free += (unsigned int)size;
+    }
+}
+
+bflb_tlsf_size_container_t *bflb_tlsf_stats() {
+    static bflb_tlsf_size_container_t sizes;
+    sizes.free = 0;
+    sizes.used = 0;
+    tlsf_walk_pool(tlsf_get_pool(tlsf_ptr), tlsf_size_walker, &sizes);
+    return &sizes;
+}

--- a/components/tlsf/bflb_tlsf.h
+++ b/components/tlsf/bflb_tlsf.h
@@ -4,11 +4,17 @@
 #include <stdint.h>
 #include <string.h>
 
+typedef struct {
+    unsigned free;          /**< total free size */
+    unsigned used;          /**< total used size */
+} bflb_tlsf_size_container_t;
+
 int bflb_mmheap_init(void *begin_addr, uint32_t size);
 void *bflb_malloc(size_t nbytes);
 void bflb_free(void *ptr);
 void *bflb_realloc(void *ptr, size_t nbytes);
 void *bflb_calloc(size_t count, size_t size);
 void *bflb_malloc_align(size_t align, size_t size);
+bflb_tlsf_size_container_t *bflb_tlsf_stats();
 
 #endif

--- a/components/tlsf/tlsf.c
+++ b/components/tlsf/tlsf.c
@@ -7,6 +7,8 @@
 
 #include "tlsf.h"
 
+#pragma GCC diagnostic ignored "-Wunused-value"
+
 #if defined(__cplusplus)
     #define tlsf_decl inline
 #else
@@ -1066,7 +1068,7 @@ void tlsf_remove_pool(tlsf_t tlsf, pool_t pool)
 ** TLSF main interface.
 */
 
-#if _DEBUG
+#ifdef _DEBUG
 int test_ffs_fls()
 {
     /* Verify ffs/fls work properly. */
@@ -1096,7 +1098,7 @@ int test_ffs_fls()
 
 tlsf_t tlsf_create(void *mem)
 {
-#if _DEBUG
+#ifdef _DEBUG
     if (test_ffs_fls())
     {
         return 0;


### PR DESCRIPTION
when CONFIG_TLSF is enabled, board.c for bl808 failed to compile as it was trying to print out system_mmheap which wasn't used. 

add a function to export used/free memory from TLSF and print that out in board.c