### PR TITLE
[usbd] suspend and resume interrupt, deinitialize fix

### DIFF
--- a/components/usb/cherryusb/common/usb_dc.h
+++ b/components/usb/cherryusb/common/usb_dc.h
@@ -144,6 +144,14 @@ int usbd_ep_start_read(const uint8_t ep, uint8_t *data, uint32_t data_len);
 /* usb dcd irq callback */
 
 /**
+ * @brief Usb resume irq callback.
+ */
+void usbd_event_resume_handler(void);
+/**
+ * @brief Usb suspend irq callback.
+ */
+void usbd_event_suspend_handler(void);
+/**
  * @brief Usb reset irq callback.
  */
 void usbd_event_reset_handler(void);

--- a/drivers/lhal/src/bflb_usb_v2.c
+++ b/drivers/lhal/src/bflb_usb_v2.c
@@ -591,6 +591,11 @@ int usb_dc_init(void)
     return 0;
 }
 
+int usb_dc_deinit(void)
+{
+    return 0;
+}
+
 int usbd_set_address(const uint8_t addr)
 {
     uint32_t regval;


### PR DESCRIPTION
Hi!

I've made a couple of changes to the usbd implementation in order to support suspend and resume interrupts from the controller, as well as fixing a compile error when calling the usbd_deinitialize() function.

Regards,
Iscle