### PR TITLE
fix bflb_gpio_set and reset

### DIFF
--- a/drivers/lhal/src/bflb_gpio.c
+++ b/drivers/lhal/src/bflb_gpio.c
@@ -132,22 +132,28 @@ void bflb_gpio_deinit(struct bflb_device_s *dev, uint8_t pin)
 void bflb_gpio_set(struct bflb_device_s *dev, uint8_t pin)
 {
 #if defined(BL702) || defined(BL602)
-    putreg32(1 << (pin & 0x1f), dev->reg_base + GLB_GPIO_CFGCTL32_OFFSET);
+    uint32_t regval = getreg32(dev->reg_base + GLB_GPIO_CFGCTL32_OFFSET);
+    putreg32(regval | 1 << (pin & 0x1f), dev->reg_base + GLB_GPIO_CFGCTL32_OFFSET);
 #elif defined(BL702L)
-    putreg32(1 << (pin & 0x1f), dev->reg_base + GLB_GPIO_CFGCTL35_OFFSET);
+    uint32_t regval = getreg32(dev->reg_base + GLB_GPIO_CFGCTL35_OFFSET);
+    putreg32(regval | 1 << (pin & 0x1f), dev->reg_base + GLB_GPIO_CFGCTL35_OFFSET);
 #elif defined(BL616) || defined(BL808) || defined(BL606P) || defined(BL628)
-    putreg32(1 << (pin & 0x1f), dev->reg_base + GLB_GPIO_CFG138_OFFSET + ((pin >> 5) << 2));
+    uint32_t regval = getreg32(dev->reg_base + GLB_GPIO_CFG138_OFFSET + ((pin >> 5) << 2));
+    putreg32(regval | 1 << (pin & 0x1f), dev->reg_base + GLB_GPIO_CFG138_OFFSET + ((pin >> 5) << 2));
 #endif
 }
 
 void bflb_gpio_reset(struct bflb_device_s *dev, uint8_t pin)
 {
 #if defined(BL702) || defined(BL602)
-    putreg32(0 << (pin & 0x1f), dev->reg_base + GLB_GPIO_CFGCTL32_OFFSET);
+    uint32_t regval = getreg32(dev->reg_base + GLB_GPIO_CFGCTL32_OFFSET);
+    putreg32(regval & ~(1 << (pin & 0x1f)), dev->reg_base + GLB_GPIO_CFGCTL32_OFFSET);
 #elif defined(BL702L)
-    putreg32(1 << (pin & 0x1f), dev->reg_base + GLB_GPIO_CFGCTL36_OFFSET);
+    uint32_t regval = getreg32(dev->reg_base + GLB_GPIO_CFGCTL36_OFFSET);
+    putreg32(regval & ~(1 << (pin & 0x1f)), dev->reg_base + GLB_GPIO_CFGCTL36_OFFSET);
 #elif defined(BL616) || defined(BL808) || defined(BL606P) || defined(BL628)
-    putreg32(1 << (pin & 0x1f), dev->reg_base + GLB_GPIO_CFG140_OFFSET + ((pin >> 5) << 2));
+    uint32_t regval = getreg32(dev->reg_base + GLB_GPIO_CFG140_OFFSET + ((pin >> 5) << 2));
+    putreg32(regval & ~(1 << (pin & 0x1f)), dev->reg_base + GLB_GPIO_CFG140_OFFSET + ((pin >> 5) << 2));
 #endif
 }
 


### PR DESCRIPTION
This pull request try to make bflb_gpio_set and reset works correctly.

I do not understand why the OFFSET of regbase in set and reset  is different for BL702L and BL616/BL808, please verify it.

If these OFFSET need changed, you can close the full request and submit a better and correct commit.